### PR TITLE
Suppress warnings and tweak API URLs

### DIFF
--- a/lib/ruboty/rainfall_jp.rb
+++ b/lib/ruboty/rainfall_jp.rb
@@ -41,7 +41,7 @@ module Ruboty
 
       def fetch_location_name_and_coodinated_geometry(query)
         url = "http://geo.search.olp.yahooapis.jp/OpenLocalPlatform/V1/geoCoder?appid=#{YAHOO_JAPAN_APP_ID}&output=json&query=#{CGI.escape(query)}"
-        response = JSON.parse(open(url).read)
+        response = JSON.parse(OpenURI.open_uri(url).read)
         features = response["Feature"]
         if features.nil? || features.first.nil?
           return nil
@@ -51,7 +51,7 @@ module Ruboty
       
       def fetch_rainfall(geometry)
         url = "http://weather.olp.yahooapis.jp/v1/place\?appid\=#{YAHOO_JAPAN_APP_ID}\&output=json&coordinates\=#{geometry}"
-        response = JSON.parse(open(url).read)
+        response = JSON.parse(OpenURI.open_uri(url).read)
         features = response["Feature"]
         if features.nil? || features.first.nil?
           return nil

--- a/lib/ruboty/rainfall_jp.rb
+++ b/lib/ruboty/rainfall_jp.rb
@@ -40,7 +40,7 @@ module Ruboty
       private
 
       def fetch_location_name_and_coodinated_geometry(query)
-        url = "http://geo.search.olp.yahooapis.jp/OpenLocalPlatform/V1/geoCoder?appid=#{YAHOO_JAPAN_APP_ID}&output=json&query=#{CGI.escape(query)}"
+        url = "https://map.yahooapis.jp/geocode/V1/geoCoder?appid=#{YAHOO_JAPAN_APP_ID}&output=json&query=#{CGI.escape(query)}"
         response = JSON.parse(OpenURI.open_uri(url).read)
         features = response["Feature"]
         if features.nil? || features.first.nil?
@@ -50,7 +50,7 @@ module Ruboty
       end
       
       def fetch_rainfall(geometry)
-        url = "http://weather.olp.yahooapis.jp/v1/place\?appid\=#{YAHOO_JAPAN_APP_ID}\&output=json&coordinates\=#{geometry}"
+        url = "https://map.yahooapis.jp/weather/V1/place?appid=#{YAHOO_JAPAN_APP_ID}&output=json&coordinates=#{geometry}"
         response = JSON.parse(OpenURI.open_uri(url).read)
         features = response["Feature"]
         if features.nil? || features.first.nil?


### PR DESCRIPTION
Hi. Thank you for the useful plugin!

This pull request has two changes, which do not change any behavior.


## Replace `Kernel.open` with `OpenURI.open_uri`.

First, it replaces `Kernel.open` with `OpenURI.open_uri`.
Because it is warned by Ruby 2.7.0-dev. Since https://github.com/ruby/ruby/commit/05aac90a1bcfeb180f5e78ea8b00a4d1b04d5eed .



Note: the warning message says "Use `URI.open`", but `URI.open` is not available Ruby 2.4 or older.
So I choose `OpenURI.open_uri` instead, becasue it is available sincce Ruby 1.8.


## Use HTTPS URL for Yahoo API


The Yahoo API has been "Always on SSL" since 2017-01-16, and the old URL has been retired since 2017-06-30 (but it looks still working). 
https://developer.yahoo.co.jp/changelog/2017-01-16-map.html

So it replaces the URLs with the new one.


And I removed unnecessary backslashes from the URL.


---

I've confirmed this patch works well.


```
> ruboty tell rainfall
Rainfall forecast: 東京都渋谷区恵比寿 (l/l: 139.71859399,35.64683720)
09-11 19:15 0.0 mm/h
09-11 19:25 0.0 mm/h
09-11 19:35 0.0 mm/h
09-11 19:45 0.0 mm/h
09-11 19:55 0.0 mm/h
09-11 20:05 0.0 mm/h
09-11 20:15 0.0 mm/h
```

Thank you.